### PR TITLE
Merged workflow jobs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -5,22 +5,16 @@ on:
     branches: [ main ]
 
 jobs:
-  swiftLint:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install Bundle
-      run: bundle install
-    - name: Run swiftlint
-      run: bundle exec fastlane swiftLintLane
-
   build:
-    needs: swiftLint
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Bundle
-      run: bundle install
-    - name: Build
-      run: bundle exec fastlane buildLane
+      - uses: actions/checkout@v2
 
+      - name: Install Bundle
+        run: bundle install
+
+      - name: Run swiftlint
+        run: bundle exec fastlane swiftLintLane
+
+      - name: Build
+        run: bundle exec fastlane buildLane

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install Bundle
+      - name: Install dependencies
         run: bundle install
 
-      - name: Run swiftlint
+      - name: Run linter
         run: bundle exec fastlane swiftLintLane
 
       - name: Build


### PR DESCRIPTION
Merged workflow jobs to reduce build time. Cloning the repository and installing dependencies now only happens once.